### PR TITLE
fix crash/exit instead of returning error for unsupported mappers

### DIFF
--- a/source/quickerNES/core/core.hpp
+++ b/source/quickerNES/core/core.hpp
@@ -138,7 +138,7 @@ class Core : private Cpu
     return 0;
   }
 
-  void open(Cart const *new_cart)
+  const char *open(Cart const *new_cart)
   {
     close();
     init();
@@ -153,7 +153,7 @@ class Core : private Cpu
     if (mapper == nullptr)
     {
       fprintf(stderr, "Could not find mapper for code: %u\n", mapperCode);
-      exit(-1);
+      return "Unsupported mapper";
     }
 
     // Assigning backwards pointers to cartdrige and emulator now
@@ -165,6 +165,8 @@ class Core : private Cpu
     cart = new_cart;
     memset(impl->unmapped_page, unmapped_fill, sizeof impl->unmapped_page);
     reset(true, true);
+
+    return nullptr;
   }
 
   inline void serializeState(jaffarCommon::serializer::Base &serializer) const

--- a/source/quickerNES/core/emu.cpp
+++ b/source/quickerNES/core/emu.cpp
@@ -78,16 +78,19 @@ inline void Emu::clear_sound_buf()
   sound_buf->clear();
 }
 
-void Emu::set_cart(Cart const *new_cart)
+const char *Emu::set_cart(Cart const *new_cart)
 {
   auto_init();
-  emu.open(new_cart);
+  const char *error = emu.open(new_cart);
+  if (error) return error;
 
   channel_count_ = Apu::osc_count + emu.mapper->channel_count();
   sound_buf->set_channel_count(channel_count());
   set_equalizer(equalizer_);
   enable_sound(true);
   reset();
+
+  return nullptr;
 }
 
 void Emu::reset(bool full_reset, bool erase_battery_ram)
@@ -167,10 +170,10 @@ const char *Emu::emulate_frame(uint32_t joypad1, uint32_t joypad2, uint32_t arka
 
 // Extras
 
-void Emu::load_ines(const uint8_t *buffer)
+const char *Emu::load_ines(const uint8_t *buffer)
 {
   private_cart.load_ines(buffer);
-  set_cart(&private_cart);
+  return set_cart(&private_cart);
 }
 
 void Emu::write_chr(void const *p, long count, long offset)


### PR DESCRIPTION
Should fix https://github.com/TASEmulators/BizHawk/issues/4186.

BizHawk-side diff:
```diff
diff --git a/quicknes/bizinterface.cpp b/quicknes/bizinterface.cpp
index 81249c60d..29a7cbfee 100644
--- a/quicknes/bizinterface.cpp
+++ b/quicknes/bizinterface.cpp
@@ -37,10 +37,9 @@ QN_EXPORT void qn_delete(quickerNES::Emu *e)
 	free(e);
 }
 
-QN_EXPORT const char *qn_loadines(quickerNES::Emu *e, const void *data, int length)
+QN_EXPORT const char *qn_loadines(quickerNES::Emu *e, const uint8_t *data, int length)
 {
-	e->load_ines((const uint8_t*)data);
-	return 0;
+	return e->load_ines(data);
 }
 
 QN_EXPORT const char *qn_set_sample_rate(quickerNES::Emu *e, int rate)
```